### PR TITLE
[BIOMAGE-1504] - Fix nightly CI test

### DIFF
--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -13,7 +13,7 @@ on:
           Set this variable to override that behavior and run a specific ref regardless of the environment.
         required: false
         default: ''
-      sandboxId: 
+      sandboxId:
         description: 'If staging, the sandbox id (by default: "default")'
         required: false
         default: 'default'
@@ -25,8 +25,6 @@ on:
         description: 'The namespace to search for deployments'
         required: false
         default: ''
-  schedule:
-    - cron:  '22 2 * * *'
 
 jobs:
   run-e2e:
@@ -38,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
+
       - id: logging
         name: Log GitHub input context
         env:
@@ -48,13 +46,13 @@ jobs:
       - id: checkout-correct-ref
         name: Check out the correct test code ref
         run: |-
-          # if we are in production check out the latest tag for the nightly build
+          # if ENV is set to production check out the latest tag for the nightly build
           if [ "$ENV" = "production" ] && [ "$REF" = "" ]; then
             latesttag=$(git describe --tags --abbrev=0)
             echo "Checking out ${latesttag}"
             git checkout ${latesttag}
           fi
-          # # if any ref was provided check it out
+          # if any ref was provided check it out
           if [ "$REF" != "" ]; then
             echo "Checking out $REF"
             git checkout $REF
@@ -109,7 +107,7 @@ jobs:
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
-          K8S_ENV: ${{ github.event.inputs.environment || 'production' }} 
+          K8S_ENV: ${{ github.event.inputs.environment || 'production' }}
           SANDBOX_ID: ${{ github.event.inputs.sandboxId }}
 
       - id: test
@@ -120,7 +118,7 @@ jobs:
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
-          K8S_ENV: ${{ github.event.inputs.environment || 'production' }} 
+          K8S_ENV: ${{ github.event.inputs.environment || 'production' }}
           SANDBOX_ID: ${{ github.event.inputs.sandboxId }}
 
       - id: enable-cronjob
@@ -132,16 +130,5 @@ jobs:
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
-          K8S_ENV: ${{ github.event.inputs.environment || 'production' }} 
+          K8S_ENV: ${{ github.event.inputs.environment || 'production' }}
           SANDBOX_ID: ${{ github.event.inputs.sandboxId }}
-
-      - id: send-to-slack
-        name: Send failure notification to Slack
-        if: failure() && github.event.inputs.environment == 'production' && github.event.inputs.ref == '' # just notify of failures for production nightly build
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pipelines
-          status: FAILED
-          color: danger

--- a/.github/workflows/run-nightly-e2e.yaml
+++ b/.github/workflows/run-nightly-e2e.yaml
@@ -3,6 +3,7 @@ name: Run nightly end-to-end test
 on:
   schedule:
     - cron:  '22 2 * * *'
+  workflow_dispatch:
 
 env:
   ENV: 'production'

--- a/.github/workflows/run-nightly-e2e.yaml
+++ b/.github/workflows/run-nightly-e2e.yaml
@@ -1,0 +1,51 @@
+name: Run nightly end-to-end test
+
+on:
+  schedule:
+    - cron:  '22 2 * * *'
+
+env:
+  ENV: 'production'
+
+jobs:
+  run-e2e:
+    name: 'Run nightly e2e tests against production'
+    runs-on: ubuntu-20.04
+    steps:
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - id: install
+        name: Install dependencies
+        run: |-
+          cd e2e/
+          git config --global url."https://".insteadOf ssh://
+          npm ci
+
+      - id: test
+        name: Run e2e tests
+        run: |-
+          cd e2e/
+          npm start
+        env:
+          CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
+          CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
+
+      - id: send-to-slack
+        name: Send failure notification to Slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: pipelines
+          status: FAILED
+          color: danger

--- a/.github/workflows/run-nightly-e2e.yaml
+++ b/.github/workflows/run-nightly-e2e.yaml
@@ -3,10 +3,8 @@ name: Run nightly end-to-end test
 on:
   schedule:
     - cron:  '22 2 * * *'
+  # AGI DDN'T FORGET TO REMOVE THIS!!!
   workflow_dispatch:
-
-env:
-  ENV: 'production'
 
 jobs:
   run-e2e:
@@ -42,7 +40,8 @@ jobs:
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
 
       - id: send-to-slack
-        name: Send failure notification to Slack
+        name: Send failure notification to Slack on failure
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1504

#### Link to staging deployment URL 

N/A

#### Links to any Pull Requests related to this

N/A

#### Anything else the reviewers should know about the changes here

- Created a new workflow to run the nightly E2E workflow
- Removed Slack notification from the normal E2E test workflow

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
