### PR TITLE
fix pipeline job namespace

### DIFF
--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -99,11 +99,32 @@ jobs:
         run: |-
           cd e2e/
 
-          kubectl scale --replicas 1 deploy worker --namespace worker-$SANDBOX_ID
-          kubectl patch cronjobs pipeline-scale-down-job -p "{\"spec\" : {\"suspend\" : true }}" --namespace worker-$SANDBOX_ID || true
+          # Check if there are worker and pipeline deployments
+          # If not, deploy and wait
 
-          kubectl scale --replicas 1 deploy pipeline --namespace pipeline-$SANDBOX_ID
-          kubectl patch cronjobs worker-scale-down-job -p "{\"spec\" : {\"suspend\" : true }}" --namespace worker-$SANDBOX_ID || true
+          wait_for_deployment="false"
+          ready_worker=$(kubectl get deployment --namespace worker-$SANDBOX_ID -o jsonpath='{.items[0].status.readyReplicas}')
+
+          if [ -z "$ready_worker" ]; then
+            kubectl scale --replicas 1 deploy worker --namespace worker-$SANDBOX_ID
+            kubectl patch cronjobs worker-scale-down-job -p "{\"spec\" : {\"suspend\" : true }}" --namespace worker-$SANDBOX_ID || true
+
+            wait_for_deployment="true"
+          fi
+
+          ready_pipeline=$(kubectl get deployment --namespace pipeline-$SANDBOX_ID -o jsonpath='{.items[0].status.readyReplicas}')
+
+          if [ -z "$ready_pipeline" ]; then
+            kubectl scale --replicas 1 deploy pipeline --namespace pipeline-$SANDBOX_ID
+            kubectl patch cronjobs pipeline-scale-down-job -p "{\"spec\" : {\"suspend\" : true }}" --namespace pipeline-$SANDBOX_ID || true
+
+            wait_for_deployment="true"
+          fi
+
+          # Wait 5 mins for the pods to spin up before running the test
+          if [ "$wait_for_deployment" = "true" ]; then
+            sleep 300s
+          fi
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
@@ -125,7 +146,7 @@ jobs:
         if: always()
         name: Re-enable cronjob
         run: |-
-          kubectl patch cronjobs pipeline-scale-down-job -p "{\"spec\" : {\"suspend\" : false }}" --namespace worker-$SANDBOX_ID || true
+          kubectl patch cronjobs pipeline-scale-down-job -p "{\"spec\" : {\"suspend\" : false }}" --namespace pipeline-$SANDBOX_ID || true
           kubectl patch cronjobs worker-scale-down-job -p "{\"spec\" : {\"suspend\" : false }}" --namespace worker-$SANDBOX_ID || true
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}

--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -102,27 +102,32 @@ jobs:
           # Check if there are worker and pipeline deployments
           # If not, deploy and wait
 
-          wait_for_deployment="false"
-          ready_worker=$(kubectl get deployment --namespace worker-$SANDBOX_ID -o jsonpath='{.items[0].status.readyReplicas}')
+          WAIT_FOR_DEPLOYMENT="false"
 
-          if [ -z "$ready_worker" ]; then
+          # Get the number of worker deployment replicas
+          WORKER_REPLICAS=$(kubectl get deployment --namespace worker-$SANDBOX_ID -o jsonpath='{.items[0].status.replicas}')
+
+          # If there are no worker replicas, increase the replica count
+          if [ -z "$WORKER_REPLICAS" ]; then
             kubectl scale --replicas 1 deploy worker --namespace worker-$SANDBOX_ID
             kubectl patch cronjobs worker-scale-down-job -p "{\"spec\" : {\"suspend\" : true }}" --namespace worker-$SANDBOX_ID || true
 
-            wait_for_deployment="true"
+            WAIT_FOR_DEPLOYMENT="true"
           fi
 
-          ready_pipeline=$(kubectl get deployment --namespace pipeline-$SANDBOX_ID -o jsonpath='{.items[0].status.readyReplicas}')
+          # Get the number of pipeline deployment replicas
+          PIPELINE_REPLICAS=$(kubectl get deployment --namespace pipeline-$SANDBOX_ID -o jsonpath='{.items[0].status.replicas}')
 
-          if [ -z "$ready_pipeline" ]; then
+          # If there are no pipeline replicas, increase the replica count
+          if [ -z "$PIPELINE_REPLICAS" ]; then
             kubectl scale --replicas 1 deploy pipeline --namespace pipeline-$SANDBOX_ID
             kubectl patch cronjobs pipeline-scale-down-job -p "{\"spec\" : {\"suspend\" : true }}" --namespace pipeline-$SANDBOX_ID || true
 
-            wait_for_deployment="true"
+            WAIT_FOR_DEPLOYMENT="true"
           fi
 
-          # Wait 5 mins for the pods to spin up before running the test
-          if [ "$wait_for_deployment" = "true" ]; then
+          # If there is a worker or pipeline being scaled up, wait 5 mins for the pods to spin up before running the test
+          if [ "$WAIT_FOR_DEPLOYMENT" = "true" ]; then
             sleep 300s
           fi
         env:


### PR DESCRIPTION
# Background
#### Link to issue 
E2E tests are failing because there are no available pipeline and worker pods

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
Add check in workflow to increase deployed pods and wait if worker and pipeline needs to be scaled up

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
