### PR TITLE
Retry while waiting for pod to scale up

### DIFF
--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -127,7 +127,7 @@ jobs:
           fi
 
           # Set as output the minified JSON.
-          echo "::set-output name=wait-for-deployment::$(WAIT_FOR_DEPLOYMENT)"
+          echo "::set-output name=wait-for-deployment::$WAIT_FOR_DEPLOYMENT"
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}

--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -126,15 +126,30 @@ jobs:
             WAIT_FOR_DEPLOYMENT="true"
           fi
 
-          # If there is a worker or pipeline being scaled up, wait 5 mins for the pods to spin up before running the test
-          if [ "$WAIT_FOR_DEPLOYMENT" = "true" ]; then
-            sleep 300s
-          fi
+          # Set as output the minified JSON.
+          echo "::set-output name=wait-for-deployment::$(WAIT_FOR_DEPLOYMENT)"
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
           K8S_ENV: ${{ github.event.inputs.environment || 'production' }}
           SANDBOX_ID: ${{ github.event.inputs.sandboxId }}
+
+      - id: wait-pod-scale-up
+        if: steps.scale-and-disable.outputs.wait-for-deployment == "true"
+        name: Wait and retry until pod scales up
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 10
+          max_attempts: 7
+          retry_on: error
+          command: |
+            WORKER_REPLICAS=$(kubectl get deployment --namespace worker-$SANDBOX_ID -o jsonpath='{.items[0].status.readyReplicas}')
+            PIPELINE_REPLICAS=$(kubectl get deployment --namespace pipeline-$SANDBOX_ID -o jsonpath='{.items[0].status.readyReplicas}')
+
+            if [ -z "$WORKER_REPLICAS" ] || [ -z "$PIPELINE_REPLICAS" ]; then
+              return 1
+            fi
+          on_retry_command: sleep $(shuf -i 60-70 -n 1)s
 
       - id: test
         name: Run e2e tests

--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -135,7 +135,7 @@ jobs:
           SANDBOX_ID: ${{ github.event.inputs.sandboxId }}
 
       - id: wait-pod-scale-up
-        if: steps.scale-and-disable.outputs.wait-for-deployment == "true"
+        if: steps.scale-and-disable.outputs.wait-for-deployment == 'true'
         name: Wait and retry until pod scales up
         uses: nick-invision/retry@v2
         with:


### PR DESCRIPTION
# Background
#### Link to issue 

Our testing implementation can check if the pipeline and worker pods are scaled up before running the test. If the pods are not scaled up, the test runner scales the pod up and waits for 5 mins for the pods to scale up before continuing the test. However, pods may scale up earlier or later than this. This PR introduces a better approach to checking if the pods have scaled up.

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
