### PR TITLE
Update run-e2e.yaml

### DIFF
--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -27,7 +27,7 @@ on:
         default: ''
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ci-${{ github.event.inputs.environment }}-${{ github.event.inputs.sandboxId }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
github.ref points to `master` always so jobs from different envs cancel each other