### PR TITLE
remove biomage refs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,11 +15,11 @@ Your changes will be ready for merging after each of the steps below have been c
 
 ### Testing
 - [ ] Unit tests written
-- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
+- [ ] Tested locally with Inframock (with latest production data downloaded with cellenics experiment pull)
 - [ ] Deployed to staging
 
 To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
-To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils
+To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
 
 ### Documentation updates
 Is all relevant documentation updated to reflect the proposed changes in this PR?
@@ -32,7 +32,7 @@ Is all relevant documentation updated to reflect the proposed changes in this PR
 - [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)
 
 ### Just before merging:
-- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging
+- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/cellenics-utils is executed. This script cleans up your deployment to staging
 
 ### Optional
 - [ ] Photo of a cute animal attached to this PR

--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -82,7 +82,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - id: install
         name: Install dependencies

--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -162,6 +162,8 @@ jobs:
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
           K8S_ENV: ${{ github.event.inputs.environment || 'production' }}
           SANDBOX_ID: ${{ github.event.inputs.sandboxId }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          GITHUB_ORG: ${{ github.repository_owner }}
 
       - id: enable-cronjob
         if: always()

--- a/.github/workflows/run-nightly-e2e.yaml
+++ b/.github/workflows/run-nightly-e2e.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - id: install
         name: Install dependencies
@@ -42,6 +42,8 @@ jobs:
         env:
           CYPRESS_E2E_USERNAME: ${{ secrets.CYPRESS_E2E_USERNAME }}
           CYPRESS_E2E_PASSWORD: ${{ secrets.CYPRESS_E2E_PASSWORD }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          GITHUB_ORG: ${{ github.repository_owner }}
 
       - id: send-to-slack
         name: Send failure notification to Slack on failure

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020-2021 Biomage Ltd.
+Copyright 2021 President and Fellows of Harvard College.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 #--------------------------------------------------
 # Targets
 #--------------------------------------------------
-install: clean ## Creates venv, and adds cellenics as system command
+install: clean
 	@echo "==> Instaling dependencies..."
 	@cd e2e && npm install
 	@echo "    [✓]"

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,15 @@
 # Variables
 #--------------------------------------------------
 ifeq ($(shell uname -s),Darwin)
-    ENTRY_POINT=/usr/local/bin/biomage
+    ENTRY_POINT=/usr/local/bin/cellenics
 else
-    ENTRY_POINT=/usr/bin/biomage
+    ENTRY_POINT=/usr/bin/cellenics
 endif
 
 #--------------------------------------------------
 # Targets
 #--------------------------------------------------
-install: clean ## Creates venv, and adds biomage as system command
+install: clean ## Creates venv, and adds cellenics as system command
 	@echo "==> Instaling dependencies..."
 	@cd e2e && npm install
 	@echo "    [✓]"

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -22,9 +22,10 @@ module.exports = async (on, config) => {
     };
   }
 
+  const region = process.env.AWS_REGION || 'eu-west-1';
   const userPoolClient = new CognitoIdentityProviderClient(
     {
-      region: process.env.AWS_REGION,
+      region,
       ...additionalClientParams,
     },
   );

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -90,13 +90,5 @@ module.exports = async (on, config) => {
     throw new Error('CYPRESS_E2E_PASSSWORD must be a valid username for logging into the platform.');
   }
 
-  if (!config.env.AWS_REGION) {
-    throw new Error('AWS_REGION must be a valid aws region for logging into the platform.');
-  }
-
-  if (!config.env.GITHUB_ORG) {
-    throw new Error('GITHUB_ORG must be a valid Github Organization to determine the application URL.');
-  }
-
   return config;
 };

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "e2e",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.109.0",
         "@aws-sdk/client-sts": "^3.109.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,10 +1,10 @@
 {
   "name": "e2e",
   "version": "1.0.0",
-  "description": "End-to-end testing of Biomage single-cell platform",
+  "description": "End-to-end testing of Cellenics single-cell platform",
   "main": "index.js",
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "cypress": "^9.7.0",
     "cypress-terminal-report": "^4.0.1",


### PR DESCRIPTION
# Background
- removes biomage refs
- makes cypress tests accout agnostic
- adds `AWS_REGION` secret 

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
